### PR TITLE
Enable shadowing for raytracer pipeline

### DIFF
--- a/src/bridge/examples/simple_demo.py
+++ b/src/bridge/examples/simple_demo.py
@@ -1,4 +1,6 @@
 import argparse
+import os
+import cv2
 
 import genesis as gs
 from genesis.options.renderers import BatchRenderer
@@ -29,7 +31,8 @@ def main():
             # constraint_solver=gs.constraint_solver.Newton,
         ),
         renderer=gs.options.renderers.BatchRenderer(
-            use_rasterizer=False,
+            use_rasterizer=True,
+            batch_render_res=(512, 512),
         ),
     )
 
@@ -44,7 +47,6 @@ def main():
 
     ########################## cameras ##########################
     cam_0 = scene.add_camera(
-        res=(512, 512),
         pos=(1.5, 0.5, 1.5),
         lookat=(0.0, 0.0, 0.5),
         fov=45,
@@ -52,7 +54,6 @@ def main():
     )
     cam_0.attach(franka.links[6], trans_to_T(np.array([0.0, 0.5, 0.0])))
     cam_1 = scene.add_camera(
-        res=(512, 512),
         pos=(3.5, 0.0, 2.5),
         lookat=(0, 0, 0.5),
         fov=30,
@@ -82,7 +83,7 @@ def main():
 
     # warmup
     scene.step()
-    rgb, depth, _, _ = scene.render_all_cameras()
+    rgb, depth, _, _ = scene.render_all_cams()
 
     # Create an image exporter
     output_dir = "img_output/test"
@@ -96,7 +97,7 @@ def main():
     for i in range(n_steps):
         scene.step()
         if do_batch_dump:
-            rgb, depth, _, _ = scene.render_all_cameras()
+            rgb, depth, _, _ = scene.render_all_cams()
             exporter.export_frame_all_cameras(i, rgb=rgb, depth=depth)
         else:
             rgb, depth, _, _ = cam_0.render()


### PR DESCRIPTION
Only lights with `.castShadow` enabled will cast shadow.  To disable shadowing, just disable `.castShadow` for all lights.


**Result**
![rgb_cam1_env0_000](https://github.com/user-attachments/assets/952f5210-6d8d-48a6-8977-d7c246507b65)


**Performance**
![image](https://github.com/user-attachments/assets/84c6bbe8-068b-4983-9aa2-e132e96da8dc)

FPS dropped by about 30% with shadowing enabled, because of shadow rays.
Shadowing can be optimized with ray fetching, but this will be done in a separate PR if needed.