### PR TITLE
Require cmake version (>=3.24) and information about upgrading cmake

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,19 @@ python -m venv ~/.virtualenvs/madgs
 source ~/.virtualenvs/madgs/bin/activate
 ```
 
+### Cmake Version
+
+Make sure that you have CMake version 3.24 or higher installed. You can check your CMake version with:
+```sh
+cmake --version
+```
+
+If you need to install or update CMake, you can do so by following the instructions on the [CMake website](https://cmake.org/download/).
+Or, for Python users, you can install it via pip:
+```sh
+pip install --upgrade cmake 
+```
+
 ### Clone Madrona and Genesis
 ```
 mkdir gs_render
@@ -100,13 +113,10 @@ git clone https://github.com/Genesis-Embodied-AI/Genesis.git
 2. Install
 ```sh
 cd gs-madrona
-mkdir build
-cd build
-cmake ..
-make -j
-cd ..
-pip install -e .
-cd ..
+mkdir -p build && cd build
+cmake .. && make -j
+cd .. && pip install -e .
+
 ```
 
 ### Install Genesis


### PR DESCRIPTION
Fixing this issue when trying to install `gs-madrona` on Ubuntu 22.04

```
-- Populating madronabundledtoolchain
CMake Error at /usr/share/cmake-3.22/Modules/ExternalProject.cmake:2781 (message):
  URL_HASH is set to

    SHA256=08e37569e94479b2f585ddb1992116d38409d0300bd7366c2804b22c48fbe0bc;DOWNLOAD_EXTRACT_TIMESTAMP;TRUE

  but must be ALGO=value where ALGO is

    MD5|SHA1|SHA224|SHA256|SHA384|SHA512|SHA3_224|SHA3_256|SHA3_384|SHA3_512

  and value is a hex string.
Call Stack (most recent call first):
  /usr/share/cmake-3.22/Modules/ExternalProject.cmake:3716 (_ep_add_download_command)
  CMakeLists.txt:15 (ExternalProject_Add)

```

It requires CMake 3.24 (or newer) (see the [original repo](https://github.com/shacklettbp/madrona/tree/main))

Tested with 

`cmake version 4.0.3
`