### PR TITLE
Only define certain MACROs when they are not defined yet in CUDA

### DIFF
--- a/src/mw/device/include/cfloat
+++ b/src/mw/device/include/cfloat
@@ -2,12 +2,24 @@
 
 #include <cuda/std/cfloat>
 
+#ifndef FLT_MAX
 #define FLT_MAX (__FLT_MAX__)
-#define FLT_MIN (__FLT_MIN__)
-#
-#define DBL_MAX (__DBL_MAX__)
-#define DBL_MIN (__DBL_MIN__)
+#endif
 
+#ifndef FLT_MIN
+#define FLT_MIN (__FLT_MIN__)
+#endif
+
+#ifndef DBL_MAX
+#define DBL_MAX (__DBL_MAX__)
+#endif
+
+#ifndef DBL_MIN
+#define DBL_MIN (__DBL_MIN__)
+#endif
+
+#ifndef FLT_EPSILON
 #define FLT_EPSILON (__FLT_EPSILON__)
+#endif
 
 #include "cuda_std_post"


### PR DESCRIPTION
Some CUDA version already defined these MACROS, so only define them in gs-madrona when they are not defined yet.