### PR TITLE
Bump version from 0.0.7.post2 to 0.0.8

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gs-madrona"
-version = "0.0.7.post2"
+version = "0.0.8"
 description = "A fork from the official Madrona. The fork will be used for Genesis's own Madrona integration."
 readme = {file = "README.md", content-type = "text/markdown"}
 license = { text = "MIT" }


### PR DESCRIPTION
## Summary
- Bump `gs-madrona` version from `0.0.7.post2` to `0.0.8`.

Includes one feature commit since the previous release:
- #53 — Add per-environment geom visibility mask for heterogeneous entities

## Test plan
- [ ] CI: cibuildwheel matrix passes on `ubuntu-24.04`
- [ ] After merge: cut GitHub release `v0.0.8` to trigger the PyPI publish job