### PR TITLE
[BUG FIX] Clamp BatchRenderer deferred RGB packing

### DIFF
--- a/src/render/shaders/draw_deferred_rgb.hlsl
+++ b/src/render/shaders/draw_deferred_rgb.hlsl
@@ -63,7 +63,9 @@ float calculateLinearDepth(float depth_in, uint view_idx)
 
 uint32_t float3ToUint32(float3 v)
 {
-    return (uint32_t)(v.x * 255.0f) | ((uint32_t)(v.y * 255.0f) << 8) | ((uint32_t)(v.z * 255.0f) << 16) | (255 << 24);
+    // Deferred RGB is LDR; tone-map HDR lighting before packing it into bytes.
+    uint3 quant = (uint3)(255.0f * clamp(v, 0.0f, 1.0f));
+    return quant.r | (quant.g << 8) | (quant.b << 16) | (255 << 24);
 }
 
 float linearToSRGB(float v)

--- a/src/render/shaders/draw_deferred_rgb.hlsl
+++ b/src/render/shaders/draw_deferred_rgb.hlsl
@@ -65,7 +65,7 @@ uint32_t float3ToUint32(float3 v)
 {
     // Deferred RGB is LDR; tone-map HDR lighting before packing it into bytes.
     uint3 quant = (uint3)(255.0f * clamp(v, 0.0f, 1.0f));
-    return quant.r | (quant.g << 8) | (quant.b << 16) | (255 << 24);
+    return quant.r | (quant.g << 8) | (quant.b << 16) | ((uint32_t)255 << 24);
 }
 
 float linearToSRGB(float v)


### PR DESCRIPTION
## Why

BatchRenderer packs deferred RGB into 8-bit channels. Direct-light values above one were converted to integers before saturation, allowing high bits to spill into adjacent channels and producing cyan/blue material corruption.

## What changed

- Clamp deferred RGB to the representable `[0, 1]` range before byte packing.
- Document that this is an LDR output boundary: HDR lighting needs tone mapping upstream rather than relying on overflow behavior.

## Impact / safety properties

The change preserves all in-range colors and prevents one channel from contaminating another. Values above one now saturate predictably instead of corrupting the packed pixel.

## Validation

Rendered a textured tan vehicle under direct light: BatchRenderer retains the intended material without cyan/blue artifacts. Rasterizer remains correct.

## Stack

This branch contains one commit on top of [#56](https://github.com/Genesis-Embodied-AI/gs-madrona/pull/56). GitHub cannot select another fork branch as this PR’s base, so it targets `main`; after #56 merges, this becomes a standalone one-commit fix.

Fixes #58.