### PR TITLE
[Bug Fix] Fix hardcoded CUDA lib load

### DIFF
--- a/src/common/cuda_utils.cpp
+++ b/src/common/cuda_utils.cpp
@@ -22,7 +22,15 @@ void CudaDynamicLoader::ensureLoaded() {
         fprintf(stderr, "Failed to load Nvidia CUDA driver library: %s\n", dlerror());
         std::abort();
     }
-    for (const char* name : std::array{"libnvrtc.so.13", "libnvrtc.so.12", "libnvrtc.so"}) {
+    const char *nvrtc_names[] = {
+#if CUDART_VERSION >= 13000
+        "libnvrtc.so.13",
+#else
+        "libnvrtc.so.12",
+#endif
+        "libnvrtc.so",
+    };
+    for (const char* name : nvrtc_names) {
         nvrtc_handle_ = dlopen(name, RTLD_LAZY | RTLD_LOCAL);
         if (nvrtc_handle_) {
             break;


### PR DESCRIPTION
This library currently hardcodes the loading order for `libnvrtc.so` to prefer `so.13` over `so.12`.

This makes it so that users with both CUDA 13 and 12 installed, but using CUDA 12 will run into the following error when attempting to use `gs.BatchRenderer`:

```
CUDA linking Failed!
ERROR 4 in nvvmAddNVVMContainerToProgram, may need newer version of nvJitLink library


Error at /project/src/mw/cuda_exec.cpp:1197 in auto madrona::buildBVHKernels(const CompileConfig &, int32_t, std::pair<int, int>, CudaBatchRenderConfig::RenderMode)::(anonymous class)::operator()(nvJitLinkResult) const
nvJitLink error: Internal error
Aborted (core dumped)
```
Rather than hardcoding, the proper library should be loaded depending on the user's `CUDART_VERSION`. After implementing fix, I can affirm that batch rendering in genesis now works using CUDA 12 on a system with 13 installed.

Relevant issues can be found here:
https://github.com/Genesis-Embodied-AI/genesis-world/issues/2089
https://github.com/Genesis-Embodied-AI/genesis-world/issues/2133
https://github.com/Genesis-Embodied-AI/genesis-world/issues/2814
