### PR TITLE
Write the compiled kernel cache atomically to prevent crashes when starting renderers concurrently.

### DIFF
--- a/src/mw/cuda_exec.cpp
+++ b/src/mw/cuda_exec.cpp
@@ -13,6 +13,8 @@
 #include <filesystem>
 #include <charconv>
 
+#include <unistd.h>
+
 #include <cuda/atomic>
 
 #include <madrona/mw_gpu.hpp>
@@ -1029,16 +1031,22 @@ static __attribute__((always_inline)) inline void dispatch(
     REQ_NVJITLINK(nvJitLinkGetLinkedCubin(linker, linked_cubin.data()));
 
     if (!cache_path.empty()) {
-        std::ofstream cache_file(cache_path.c_str(), std::ios::binary);
-        cache_file.write(init_ecs_name.data(), init_ecs_name.size() + 1);
-        cache_file.write(init_worlds_name.data(), init_worlds_name.size() + 1);
-        cache_file.write(init_tasks_name.data(), init_tasks_name.size() + 1);
-        while (size_t(cache_file.tellp()) % 4 != 0) {
-            cache_file.put(0);
+        // Write to a per-process temporary file and atomically rename it into place. A plain in-place write lets a
+        // concurrent process that finds the cache fresh load a half-written (corrupt) cubin and abort in
+        // cuModuleLoadData; an atomic rename guarantees readers only ever observe a complete file, and parallel
+        // compilers each write their own temp so the final rename wins with a valid result.
+        const std::string tmp_path = cache_path + ".tmp." + std::to_string(getpid());
+        {
+            std::ofstream cache_file(tmp_path.c_str(), std::ios::binary);
+            cache_file.write(init_ecs_name.data(), init_ecs_name.size() + 1);
+            cache_file.write(init_worlds_name.data(), init_worlds_name.size() + 1);
+            cache_file.write(init_tasks_name.data(), init_tasks_name.size() + 1);
+            while (size_t(cache_file.tellp()) % 4 != 0) {
+                cache_file.put(0);
+            }
+            cache_file.write(linked_cubin.data(), linked_cubin.size());
         }
-        cache_file.write(linked_cubin.data(), linked_cubin.size());
-
-        cache_file.close();
+        std::filesystem::rename(tmp_path, cache_path);
     }
 
     if (verbose_compile) {
@@ -1285,9 +1293,14 @@ static BVHKernels buildBVHKernels(const CompileConfig &cfg,
         REQ_NVJITLINK(nvJitLinkGetLinkedCubin(linker, linked_cubin.data()));
 
         if (!cache_path.empty()) {
-            std::ofstream cache_file(cache_path, std::ios::binary);
-            cache_file.write(linked_cubin.data(), linked_cubin.size());
-            cache_file.close();
+            // Atomic write (temp + rename); see the megakernel cache above for why in-place writes are unsafe under
+            // concurrent access.
+            const std::string tmp_path = cache_path + ".tmp." + std::to_string(getpid());
+            {
+                std::ofstream cache_file(tmp_path, std::ios::binary);
+                cache_file.write(linked_cubin.data(), linked_cubin.size());
+            }
+            std::filesystem::rename(tmp_path, cache_path);
         }
 
         REQ_CU(CudaDynamicLoader::cuModuleLoadData(&mod, linked_cubin.data()));


### PR DESCRIPTION
## Problem

Starting several batched renderers concurrently on the same host (e.g. `pytest -n <N>` GPU test runs, or multiple training workers) intermittently aborts with `SIGABRT` (exit 134) inside `cuModuleLoadData`, once the compiled kernel cache exists on disk. The failure is non-deterministic and disappears when the run is serialized.

## Root cause

The megakernel and BVH kernel caches are written **in place** with a plain `std::ofstream` at a shared path (`$MADRONA_ROOT_CACHE_DIR/kernel_cache`, `$HOME/.cache/madrona` by default). When one process is part-way through writing the cubin, a second process that finds the cache present (`kernelCacheNeedsRecompile` only checks existence + `last_write_time`) opens it and feeds a truncated, half-written buffer to `cuModuleLoadData`, which aborts.

This was confirmed deterministically: truncating the cache file to a partial cubin reproduces the exact `SIGABRT` exit 134.

## Fix

Write each cache to a per-process temporary file (`<cache_path>.tmp.<pid>`) and `std::filesystem::rename` it into place. POSIX `rename` is atomic, so a reader observes either the previous complete file or the new complete file, never a partial one. Concurrent compilers each write their own temp and the final rename wins with a valid, self-consistent cubin.

Applied to both the megakernel cache write and the BVH kernel cache write.

## Validation

- Root cause and failure mode reproduced deterministically (truncated cache -> exit 134).
- Atomic-rename write makes torn reads unobservable by construction.
