### PR TITLE
Resolve CUDA JIT libraries from pinned cu12 packages, not the host

### DIFF
--- a/include/madrona/cuda_utils.hpp
+++ b/include/madrona/cuda_utils.hpp
@@ -74,11 +74,10 @@ public:
     inline static nvrtcResult (*nvrtcGetLTOIR)(nvrtcProgram, char*) = nullptr;
     inline static nvrtcResult (*nvrtcGetCUBINSize)(nvrtcProgram, size_t*) = nullptr;
     inline static nvrtcResult (*nvrtcGetCUBIN)(nvrtcProgram, char*) = nullptr;
-    inline static nvrtcResult (*nvrtcGetErrorString)(nvrtcResult) = nullptr;
+    inline static const char* (*nvrtcGetErrorString)(nvrtcResult) = nullptr;
 
 private:
     static inline void* cuda_handle_;
-    static inline void* nvrtc_handle_;
 };
 
 namespace cu {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,24 @@ classifiers = [
 ]
 keywords = ["rendering", "graphics", "3d", "vulkan", "visualization", "raytracing"]
 
+# The runtime CUDA JIT compiler (nvrtc) and linker (nvJitLink) are not bundled
+# in the wheel; they are resolved at load time from these pip packages via
+# RPATH (see CMAKE_INSTALL_RPATH below), mirroring how torch ships its CUDA
+# deps. At first render nvrtc compiles our device code against the CCCL/CUB
+# headers bundled from the 12.8 build toolkit and must target Blackwell
+# (sm_120), so it has to be >= 12.8; we floor both packages there. This
+# intentionally conflicts with a torch installed from a pre-12.8 index (e.g.
+# .../whl/cu126, which pins these to 12.6.x): such a torch is genuinely
+# unsupported, and a clear pip resolution error is better than a cryptic nvrtc
+# failure at first render. The "-cu12" package names cap the major at 12
+# (matching our libnvrtc.so.12 / libnvJitLink.so.12 soname link), and pip keeps
+# both on a single minor so they stay mutually consistent. torch itself is not
+# declared, leaving users free to pick any cu12 (>= 12.8) variant.
+dependencies = [
+  "nvidia-cuda-nvrtc-cu12>=12.8",
+  "nvidia-nvjitlink-cu12>=12.8",
+]
+
 [project.urls]
 Repository = "https://github.com/Genesis-Embodied-AI/gs-madrona"
 
@@ -45,7 +63,12 @@ search.site-packages = true
 [tool.scikit-build.cmake.define]
 CMAKE_INSTALL_RPATH_USE_LINK_PATH = true
 CMAKE_BUILD_WITH_INSTALL_RPATH = true
-CMAKE_INSTALL_RPATH = '$ORIGIN'
+# Resolve the CUDA runtime-JIT libraries (libnvrtc.so.12, libnvJitLink.so.12)
+# from the user's pip-installed nvidia-*-cu12 packages (siblings of this one in
+# site-packages, e.g. brought in by torch), exactly like torch resolves its own
+# CUDA deps. This keeps them out of the wheel (size) while pinning them to the
+# cu12 series the extension was built against, independent of the host toolkit.
+CMAKE_INSTALL_RPATH = '$ORIGIN;$ORIGIN/../nvidia/cuda_nvrtc/lib;$ORIGIN/../nvidia/nvjitlink/lib'
 CMAKE_DISABLE_FIND_PACKAGE_X11 = true
 CMAKE_INTERPROCEDURAL_OPTIMIZATION = true
 CMAKE_CXX_FLAGS_RELEASE = "-O3 -DNDEBUG -ffunction-sections -fdata-sections"
@@ -63,7 +86,9 @@ config-settings = { "wheel.py-api" = "cp312" }
 select = "cp3{10,11}-*"
 config-settings = {}
 repair-wheel-command = [
-  "auditwheel repair --zip-compression-level=9 -w {dest_dir} {wheel}"
+  # Do not vendor the CUDA JIT libs; they are provided by the nvidia-*-cu12
+  # dependencies and resolved via RPATH (keeps the wheel under PyPI's limit).
+  "auditwheel repair --exclude libnvrtc.so.12 --exclude libnvJitLink.so.12 --zip-compression-level=9 -w {dest_dir} {wheel}"
 ]
 
 [tool.cibuildwheel.linux]
@@ -75,7 +100,9 @@ before-all = [
   'rpm -ivh --nodeps cuda-nvcc-12-8-*.rpm',
 ]
 repair-wheel-command = [
-  "auditwheel repair --zip-compression-level=9 -w {dest_dir} {wheel}",
+  # Do not vendor the CUDA JIT libs; they are provided by the nvidia-*-cu12
+  # dependencies and resolved via RPATH (keeps the wheel under PyPI's limit).
+  "auditwheel repair --exclude libnvrtc.so.12 --exclude libnvJitLink.so.12 --zip-compression-level=9 -w {dest_dir} {wheel}",
   "pipx run abi3audit --strict --report {wheel}",
 ]
 

--- a/src/bridge/CMakeLists.txt
+++ b/src/bridge/CMakeLists.txt
@@ -74,15 +74,11 @@ target_link_libraries(_gs_madrona_batch_renderer PRIVATE
 )
 
 if (SKBUILD)
-    if (CUDA_REQUIRED_ARG)
-        find_library(CUDA_NVJITLINK_LIBRARY nvJitLink
-            PATHS ${CUDAToolkit_LIBRARY_DIR}
-            REQUIRED)
-        get_filename_component(CUDA_NVJITLINK_LIBRARY_REALPATH "${CUDA_NVJITLINK_LIBRARY}" REALPATH)
-        get_filename_component(CUDA_NVJITLINK_NAME "${CUDA_NVJITLINK_LIBRARY}" NAME)
-        install(FILES ${CUDA_NVJITLINK_LIBRARY_REALPATH} DESTINATION gs_madrona
-            RENAME "${CUDA_NVJITLINK_NAME}.${CUDAToolkit_VERSION_MAJOR}")
-    endif()
+    # nvJitLink and nvrtc are intentionally NOT bundled here. They are declared
+    # as pip dependencies (nvidia-nvjitlink-cu12 / nvidia-cuda-nvrtc-cu12) and
+    # resolved at load time from the sibling nvidia/*/lib packages via RPATH,
+    # mirroring how torch ships its CUDA deps (see pyproject.toml). Bundling a
+    # copy in gs_madrona/ would shadow the pinned package via $ORIGIN.
 
     find_package(embree REQUIRED)
     get_target_property(madrona_embree_shlib embree IMPORTED_LOCATION_RELEASE)

--- a/src/bridge/gs_madrona/renderer_gs.py
+++ b/src/bridge/gs_madrona/renderer_gs.py
@@ -1,6 +1,4 @@
 import os
-import ctypes
-from importlib.metadata import distribution, PackageNotFoundError
 from pathlib import Path
 from typing import Tuple
 
@@ -66,16 +64,6 @@ class MadronaBatchRendererAdapter:
         cam_znear = cam_znears_tensor.cpu().numpy()
         cam_zfar = cam_zfars_tensor.cpu().numpy()
         cam_proj_type = cam_proj_types_tensor.int().cpu().numpy()
-
-        # Preload Nvidia compiler runtime if available (i.e. torch is not built from source)
-        try:
-            dist = distribution("nvidia_cuda_nvrtc_cu12")
-            for file in dist.files:
-                if file.name.startswith("libnvrtc.so.1"):
-                    ctypes.CDLL(dist.locate_file(file), ctypes.RTLD_LOCAL)
-                    break
-        except PackageNotFoundError:
-            pass
 
         self.madrona = MadronaBatchRenderer(
             gpu_id=gpu_id,

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -178,6 +178,13 @@ if (CUDAToolkit_FOUND)
     target_link_libraries(madrona_cuda
         PUBLIC
             CUDA::cudart_static
+            # Link nvrtc dynamically (DT_NEEDED libnvrtc.so.12) and resolve it,
+            # like nvJitLink, from the pinned nvidia-cuda-nvrtc-cu12 package via
+            # RPATH ($ORIGIN/../nvidia/cuda_nvrtc/lib) rather than the host's
+            # CUDA. This mirrors how torch ships its CUDA dependencies: the wheel
+            # stays small (libs are declared, not bundled) and nvrtc always
+            # matches the cu12 nvJitLink it feeds, regardless of the host toolkit.
+            CUDA::nvrtc
         PRIVATE
             madrona_err
             madrona_noexceptrtti

--- a/src/common/cuda_utils.cpp
+++ b/src/common/cuda_utils.cpp
@@ -22,17 +22,6 @@ void CudaDynamicLoader::ensureLoaded() {
         fprintf(stderr, "Failed to load Nvidia CUDA driver library: %s\n", dlerror());
         std::abort();
     }
-    for (const char* name : std::array{"libnvrtc.so.13", "libnvrtc.so.12", "libnvrtc.so"}) {
-        nvrtc_handle_ = dlopen(name, RTLD_LAZY | RTLD_LOCAL);
-        if (nvrtc_handle_) {
-            break;
-        }
-    }
-    if (!nvrtc_handle_) {
-        fprintf(stderr, "Failed to load Nvidia  runtime compilation library: %s\n", dlerror());
-        std::abort();
-    }
-
 #define LOAD_SYM(handle, name)                                 \
     name = (decltype(name))dlsym(handle, #name);               \
     if (!name) {                                               \
@@ -79,30 +68,35 @@ void CudaDynamicLoader::ensureLoaded() {
     LOAD_CUDA_SYM(cuGetErrorString);
 #undef LOAD_CUDA_SYM
 
-#define LOAD_NVRTC_SYM(name) LOAD_SYM(nvrtc_handle_, name)
-    LOAD_NVRTC_SYM(nvrtcCreateProgram);
-    LOAD_NVRTC_SYM(nvrtcDestroyProgram);
-    LOAD_NVRTC_SYM(nvrtcCompileProgram);
-    LOAD_NVRTC_SYM(nvrtcGetPTX);
-    LOAD_NVRTC_SYM(nvrtcGetPTXSize);
-    LOAD_NVRTC_SYM(nvrtcGetProgramLog);
-    LOAD_NVRTC_SYM(nvrtcGetProgramLogSize);
-    LOAD_NVRTC_SYM(nvrtcAddNameExpression);
-    LOAD_NVRTC_SYM(nvrtcGetLoweredName);
-    LOAD_NVRTC_SYM(nvrtcGetLTOIRSize);
-    LOAD_NVRTC_SYM(nvrtcGetLTOIR);
-    LOAD_NVRTC_SYM(nvrtcGetCUBINSize);
-    LOAD_NVRTC_SYM(nvrtcGetCUBIN);
-    LOAD_NVRTC_SYM(nvrtcGetErrorString);
-#undef LOAD_NVRTC_SYM
+    // nvrtc is a normal (dynamic) link-time dependency of this library
+    // (DT_NEEDED libnvrtc.so.12, resolved via RPATH from the pinned cu12
+    // package). Bind the entry points directly to those linked symbols rather
+    // than dlopen'ing a host nvrtc: dlopen ignores DT_RUNPATH, so a plain
+    // dlopen("libnvrtc.so") could pick up a mismatched host nvrtc (e.g. .so.13)
+    // whose PTX output the cu12 nvJitLink cannot link. Binding to the linked
+    // symbols keeps nvrtc and nvJitLink on the same cu12 version.
+#define BIND_NVRTC_SYM(name) name = &(::name)
+    BIND_NVRTC_SYM(nvrtcCreateProgram);
+    BIND_NVRTC_SYM(nvrtcDestroyProgram);
+    BIND_NVRTC_SYM(nvrtcCompileProgram);
+    BIND_NVRTC_SYM(nvrtcGetPTX);
+    BIND_NVRTC_SYM(nvrtcGetPTXSize);
+    BIND_NVRTC_SYM(nvrtcGetProgramLog);
+    BIND_NVRTC_SYM(nvrtcGetProgramLogSize);
+    BIND_NVRTC_SYM(nvrtcAddNameExpression);
+    BIND_NVRTC_SYM(nvrtcGetLoweredName);
+    BIND_NVRTC_SYM(nvrtcGetLTOIRSize);
+    BIND_NVRTC_SYM(nvrtcGetLTOIR);
+    BIND_NVRTC_SYM(nvrtcGetCUBINSize);
+    BIND_NVRTC_SYM(nvrtcGetCUBIN);
+    BIND_NVRTC_SYM(nvrtcGetErrorString);
+#undef BIND_NVRTC_SYM
 
 #undef LOAD_SYM
 
     std::atexit([]() {
         dlclose(cuda_handle_);
         cuda_handle_ = nullptr;
-        dlclose(nvrtc_handle_);
-        nvrtc_handle_ = nullptr;
     });
   });
 }

--- a/src/mw/CMakeLists.txt
+++ b/src/mw/CMakeLists.txt
@@ -29,7 +29,10 @@ target_link_libraries(madrona_mw_gpu
         madrona_hdrs madrona_cuda
     PRIVATE
         madrona_mw_core
-        CUDA::nvJitLink  # FIXME: CUDA::nvJitLink_static
+        # Dynamic nvJitLink (DT_NEEDED libnvJitLink.so.12), resolved from the
+        # pinned nvidia-nvjitlink-cu12 package via RPATH like torch does; see
+        # madrona_cuda for the rationale.
+        CUDA::nvJitLink
 )
 
 set(MADRONA_MW_GPU_COMPILE_FLAGS


### PR DESCRIPTION
## Problem

At first render the wheel JIT-compiles its device code with **nvrtc** and links the result with **nvJitLink**. nvrtc's output must not be newer than the nvJitLink that consumes it — when the two come from different CUDA majors the link fails with:

```
ERROR 4 in nvvmAddNVVMContainerToProgram, may need newer version of nvJitLink library
```

Reported downstream in Genesis-Embodied-AI/genesis-world#2089, #2133, #2814.

The cause: nvrtc was `dlopen`'d at runtime, **preferring `libnvrtc.so.13` over `.12`**, while nvJitLink was linked (and a copy bundled) at cu12. So on a host that also has a CUDA 13 runtime present, the cu12-built wheel loaded a **cu13 nvrtc** and fed its PTX to the **cu12 nvJitLink** → version mismatch and a crash on the first render.

This supersedes #59 (thanks @QuantuMope for surfacing and diagnosing the hardcoded-load issue). #59's reorder fixed the symptom on specific hosts but isn't general — it still depends on which nvrtc happens to be discoverable. This PR makes the choice deterministic.

## Fix — adopt torch's model instead of `dlopen`-guessing or bundling

- **Link nvrtc dynamically** (`DT_NEEDED libnvrtc.so.12`), like nvJitLink, and bind the loader's entry points to the linked symbols. `dlopen` ignores `DT_RUNPATH`, so binding to the versioned soname is what makes resolution deterministic and keeps nvrtc on the same cu12 major as nvJitLink.
- **Declare** `nvidia-cuda-nvrtc-cu12` / `nvidia-nvjitlink-cu12` (`>= 12.8`) as dependencies and resolve them from the sibling `nvidia/*/lib` packages via **RPATH** (`$ORIGIN/../nvidia/...`), exactly like torch ships its own CUDA deps. Both then come from a single pinned cu12 minor and stay mutually consistent, independent of the host toolkit.
- **Stop bundling** `libnvJitLink.so.12` in the wheel and **exclude** both libs from auditwheel so they aren't vendored (keeps the wheel within PyPI limits).
- Drop the now-redundant nvrtc preload in `renderer_gs`.
- Fix the `nvrtcGetErrorString` function-pointer signature (returns `const char*`, not `nvrtcResult`).

`torch` itself is intentionally **not** declared, so users remain free to pick any cu12 (`>= 12.8`) torch variant. The `>= 12.8` floor is deliberate: nvrtc compiles the CCCL/CUB headers bundled from the 12.8 build toolkit and must target Blackwell (`sm_120`), so an older runtime is genuinely unsupported and should fail at **install** time rather than cryptically at first render.

## Validation (cluster, RTX PRO 6000 Blackwell)

| Check | Result |
|---|---|
| Build + import (no bundled JIT libs in `gs_madrona/`) | ✅ |
| `DT_NEEDED` = `libnvrtc.so.12` + `libnvJitLink.so.12`; RUNPATH → `nvidia/*/lib` | ✅ |
| Resolution with clean `LD_LIBRARY_PATH` → pip `nvidia-*-cu12` packages | ✅ |
| Control render, fresh kernel cache | ✅ |
| **Render with `libnvrtc.so.13` on `LD_LIBRARY_PATH`, fresh cache** (the bug scenario) | ✅ renders (host `.so.13` never selected) |

## Note on CUDA 13 / GB300 (`sm_130`)

Out of scope here — a cu12 wheel cannot target `sm_130`. The C++ is already CUDA-major-agnostic (the `DT_NEEDED` soname follows the build toolkit); only three packaging spots are cu12-literal (the two deps, the RPATH, the auditwheel excludes). CUDA 13 will be handled as a wholesale switch when CUDA 12 support is dropped.

## Downstream issues

Same nvJitLink-mismatch root cause reported in genesis-world:

- Genesis-Embodied-AI/genesis-world#2089 — RTX 4060 (sm_89), host CUDA 13.0 (closed)
- Genesis-Embodied-AI/genesis-world#2133 — A100 (sm_80), pinned nvrtc 12.6.77 / nvjitlink 12.6.85 yet still mismatched — a host `.so.13` was being picked up (closed)
- Genesis-Embodied-AI/genesis-world#2814 — RTX 2070 SUPER (sm_75) (open)

All three are cu12-supported arches, so this resolves the underlying bug once a gs-madrona release carrying it is consumed by genesis-world. Reporters on a torch **cu126** build (#2089, #2133) must move to a **≥ cu128** torch, since the `>= 12.8` floor deliberately conflicts with the cu126-pinned `nvidia-*-cu12 == 12.6`.

Resolves Genesis-Embodied-AI/genesis-world#2089
Resolves Genesis-Embodied-AI/genesis-world#2133
Resolves Genesis-Embodied-AI/genesis-world#2814

Closes #59
