### PR TITLE
Derive package version from the git tag (setuptools_scm)

### DIFF
--- a/.github/workflows/python-wheels.yml
+++ b/.github/workflows/python-wheels.yml
@@ -29,7 +29,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: recursive
-          fetch-depth: 1
+          fetch-depth: 0  # setuptools_scm needs full tag history to derive the version
           show-progress: true
 
       - name: Build wheels

--- a/cmake/scm_version.py
+++ b/cmake/scm_version.py
@@ -1,0 +1,15 @@
+"""Version provider for scikit-build-core, wired in pyproject.toml.
+
+The package version is the git tag (via setuptools_scm), so a release is cut
+purely by tagging ``vX.Y.Z`` -- there is no version string to bump by hand.
+"""
+
+from setuptools_scm import get_version
+
+
+def dynamic_metadata(_field: str, _settings: dict | None = None) -> str:
+    return get_version(root=".", fallback_version="0.0.0+unknown")
+
+
+def get_requires_for_dynamic_metadata(_settings: dict | None = None) -> list[str]:
+    return ["setuptools_scm>=8"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,8 @@
 [project]
 name = "gs-madrona"
-version = "0.0.8"
+# Version is derived from the git tag via setuptools_scm (see [tool.scikit-build]
+# below). Do not hardcode it here; a release is cut purely by tagging vX.Y.Z.
+dynamic = ["version"]
 description = "A fork from the official Madrona. The fork will be used for Genesis's own Madrona integration."
 readme = {file = "README.md", content-type = "text/markdown"}
 license = { text = "MIT" }
@@ -45,7 +47,7 @@ dependencies = [
 Repository = "https://github.com/Genesis-Embodied-AI/gs-madrona"
 
 [build-system]
-requires = ["scikit-build-core>=0.5.0", "nanobind>=1.3.2"]
+requires = ["scikit-build-core>=0.10", "nanobind>=1.3.2", "setuptools_scm>=8"]
 build-backend = "scikit_build_core.build"
 
 [tool.scikit-build]
@@ -59,6 +61,13 @@ editable.mode = "redirect"
 build.verbose = true
 install.strip = false
 search.site-packages = true
+# Single source of truth for the version: the git tag, via setuptools_scm.
+# `experimental` is required for an out-of-tree metadata provider; the built-in
+# scikit_build_core.metadata.setuptools_scm provider is incompatible with
+# setuptools_scm >=9, so we call setuptools_scm ourselves (see cmake/scm_version.py).
+experimental = true
+metadata.version.provider = "scm_version"
+metadata.version.provider-path = "cmake"
 
 [tool.scikit-build.cmake.define]
 CMAKE_INSTALL_RPATH_USE_LINK_PATH = true


### PR DESCRIPTION
## Problem

The version was hardcoded in `pyproject.toml` (`version = "0.0.8"`), so cutting a release tag didn't change it. Tagging `v0.0.9` while pyproject still said `0.0.8` built `gs_madrona-0.0.8` wheels, which the PyPI upload then skipped as already-existing — so **nothing shipped as 0.0.9** (0.0.9 is currently empty on PyPI).

## Fix

Derive the version from the git tag via `setuptools_scm`, using the same scikit-build-core out-of-tree metadata provider as [`nyx`](https://github.com/Genesis-Embodied-AI/nyx) (the built-in `scikit_build_core.metadata.setuptools_scm` provider is incompatible with setuptools_scm >= 9). A release is then cut **purely by tagging `vX.Y.Z`** — there is no version string to bump by hand.

- **pyproject**: `dynamic = ["version"]`; `setuptools_scm>=8` build requirement; `metadata.version.provider = "scm_version"` → `cmake/scm_version.py`; `experimental = true`.
- **python-wheels.yml**: `fetch-depth: 0` for tag history, and forward the runner-resolved version into cibuildwheel's manylinux containers via `SETUPTOOLS_SCM_PRETEND_VERSION` (setuptools_scm can't read git inside the build container, and would otherwise fall back to `0.0.0+unknown`).

## Validation

Building the sdist through scikit-build-core resolves the version from the tag end-to-end:

```
*** scikit-build-core 1.0.3 (sdist)
Successfully built gs_madrona-0.0.10.dev0+gc7d64d382.d20260722.tar.gz
```

The `.dev0`/date suffix is only the dirty worktree during testing; a clean tagged commit yields the exact tag (e.g. `0.0.9`).

Once this lands, the `v0.0.9` tag/release will be recreated on top of it so the release builds and publishes `0.0.9` correctly.
